### PR TITLE
#1 added missing parameters to example config

### DIFF
--- a/src/investhor/config/sell_stale.json.example
+++ b/src/investhor/config/sell_stale.json.example
@@ -1,3 +1,9 @@
 {
-    "max_days_till_next_payment": 5
+  max_days_till_next_payment: 5,
+  no_discount: 0,
+  low_discount: 1,
+  medium_discount: 3,
+  high_discount: 5,
+  crazy_discount: 20,
+  total_discount: 50
 }


### PR DESCRIPTION
The example config file for `sell.py` was missing some parameters, what caused exceptions when using this config.